### PR TITLE
Dont minify CSS in debug

### DIFF
--- a/src/Lib/Shrink.php
+++ b/src/Lib/Shrink.php
@@ -70,7 +70,7 @@ class Shrink{
 			$this->debugging = true;
 			if($this->settings['debugLevel'] == 2){
 				$this->settings['js']['minifier'] = false;
-				$this->settings['minify']['minifier'] = false;
+				$this->settings['css']['minifier'] = false;
 			}
 		}
 


### PR DESCRIPTION
It should be "css" and not "minify" to disable minifying in debug mode.